### PR TITLE
Implement minimal support for ruby/servo

### DIFF
--- a/rb/lib/selenium/webdriver.rb
+++ b/rb/lib/selenium/webdriver.rb
@@ -38,6 +38,7 @@ module Selenium
     autoload :PhantomJS, 'selenium/webdriver/phantomjs'
     autoload :Remote,    'selenium/webdriver/remote'
     autoload :Safari,    'selenium/webdriver/safari'
+    autoload :Servo,     'selenium/webdriver/servo'
     autoload :Support,   'selenium/webdriver/support'
 
     # @api private

--- a/rb/lib/selenium/webdriver/common/driver.rb
+++ b/rb/lib/selenium/webdriver/common/driver.rb
@@ -54,6 +54,8 @@ module Selenium
             Edge::Driver.new(opts)
           when :remote
             Remote::Driver.new(opts)
+          when :servo
+            Servo::Driver.new(opts)
           else
             raise ArgumentError, "unknown driver: #{browser.inspect}"
           end

--- a/rb/lib/selenium/webdriver/servo.rb
+++ b/rb/lib/selenium/webdriver/servo.rb
@@ -1,0 +1,26 @@
+require 'selenium/webdriver/servo/service'
+require 'selenium/webdriver/servo/driver'
+
+module Selenium
+  module WebDriver
+    module Servo
+      def self.driver_path=(path)
+        Platform.assert_executable path
+        @driver_path = path
+      end
+
+      def self.driver_path
+        @driver_path ||= nil
+      end
+
+      def self.path=(path)
+        Platform.assert_executable path
+        @path = path
+      end
+
+      def self.path
+        @path ||= nil
+      end
+    end
+  end
+end

--- a/rb/lib/selenium/webdriver/servo/driver.rb
+++ b/rb/lib/selenium/webdriver/servo/driver.rb
@@ -1,0 +1,100 @@
+module Selenium
+  module WebDriver
+    module Servo
+      class Driver < WebDriver::Driver
+        include DriverExtensions::HasTouchScreen
+        include DriverExtensions::HasWebStorage
+        include DriverExtensions::TakesScreenshot
+
+        def initialize(opts = {})
+          opts[:desired_capabilities] = Selenium::WebDriver::Remote::Capabilities.new
+
+          unless opts.key?(:url)
+            driver_path = opts.delete(:driver_path)
+            port = opts.delete(:port) || Service::DEFAULT_PORT
+
+            opts[:driver_opts] ||= {}
+            if opts.key? :service_log_path
+              WebDriver.logger.deprecate ':service_log_path', "driver_opts: {log_path: '#{opts[:service_log_path]}'}"
+              opts[:driver_opts][:log_path] = opts.delete :service_log_path
+            end
+
+            if opts.key? :service_args
+              WebDriver.logger.deprecate ':service_args', "driver_opts: {args: #{opts[:service_args]}}"
+              opts[:driver_opts][:args] = opts.delete(:service_args)
+            end
+
+            @service = Service.new(driver_path, port, opts.delete(:driver_opts))
+            @service.start
+
+            opts[:url] = @service.uri
+          end
+
+          listener = opts.delete(:listener)
+          @bridge = Remote::Bridge.handshake(opts)
+          super(@bridge, listener: listener)
+        end
+
+        def browser
+          :servo
+        end
+
+        def quit
+          super
+        ensure
+          @service.stop if @service
+        end
+
+        private
+
+        #def create_capabilities(opts)
+        #  caps = opts.delete(:desired_capabilities) { Remote::Capabilities.chrome }
+        #  options = opts.delete(:options) { Options.new }
+
+        #  args = opts.delete(:args) || opts.delete(:switches)
+        #  if args
+        #    WebDriver.logger.deprecate ':args or :switches', 'Selenium::WebDriver::Chrome::Options#add_argument'
+        #    raise ArgumentError, ':args must be an Array of Strings' unless args.is_a? Array
+        #    args.each { |arg| options.add_argument(arg.to_s) }
+        #  end
+
+        #  profile = opts.delete(:profile)
+        #  if profile
+        #    profile = profile.as_json
+
+        #    if options.args.none? { |arg| arg =~ /user-data-dir/ }
+        #      options.add_argument("--user-data-dir=#{profile[:directory]}")
+        #    end
+
+        #    if profile[:extensions]
+        #      WebDriver.logger.deprecate 'Using Selenium::WebDriver::Chrome::Profile#extensions',
+        #                                 'Selenium::WebDriver::Chrome::Options#add_extension'
+        #      profile[:extensions].each do |extension|
+        #        options.add_encoded_extension(extension)
+        #      end
+        #    end
+        #  end
+
+        #  detach = opts.delete(:detach)
+        #  options.add_option(:detach, true) if detach
+
+        #  prefs = opts.delete(:prefs)
+        #  if prefs
+        #    WebDriver.logger.deprecate ':prefs', 'Selenium::WebDriver::Chrome::Options#add_preference'
+        #    prefs.each do |key, value|
+        #      options.add_preference(key, value)
+        #    end
+        #  end
+
+        #  options = options.as_json
+        #  caps[:chrome_options] = options unless options.empty?
+
+        #  caps[:proxy] = opts.delete(:proxy) if opts.key?(:proxy)
+        #  caps[:proxy] ||= opts.delete('proxy') if opts.key?('proxy')
+
+        #  caps
+        #end
+      end # Driver
+    end # Chrome
+  end # WebDriver
+end # Selenium

--- a/rb/lib/selenium/webdriver/servo/service.rb
+++ b/rb/lib/selenium/webdriver/servo/service.rb
@@ -1,0 +1,30 @@
+module Selenium
+  module WebDriver
+    module Servo
+      #
+      # @api private
+      #
+
+      class Service < WebDriver::Service
+        DEFAULT_PORT = 7000
+        @executable = 'servo'.freeze
+        @missing_text = <<-ERROR.gsub(/\n +| {2,}/, ' ').freeze
+          Unable to find servo. Please download the server from
+          https://download.servo.org/ and place it somewhere on your PATH.
+        ERROR
+
+        private
+
+        def start_process
+          @process = build_process(@executable_path, "--webdriver=#{@port}", *@extra_args)
+          @process.leader = true unless Platform.windows?
+          @process.start
+        end
+
+        def cannot_connect_error_text
+          "unable to connect to servo #{@host}:#{@port}"
+        end
+      end # Service
+    end # Servo
+  end # WebDriver
+end # Selenium


### PR DESCRIPTION
This PR implements minimal ruby driver for  [servo](https://servo.org/) web engine, so it can be used with Capybara in tests.

However it's not yet ready for production usages, because at the moment Servo does not support all list of webdriver commands :(. See https://github.com/servo/servo/issues/8623